### PR TITLE
Update DiamondSponsors.js consulting button: (1) replace logo from /stat

### DIFF
--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -55,7 +55,7 @@ export default function DiamondSponsors() {
           component="img"
           height="32px"
           width="32px"
-          src="/static/logo-no-padding.svg"
+          src="/static/stoked-consulting-logo.svg"
           alt="brian stoker"
           title="B STOKED"
           loading="lazy"
@@ -64,8 +64,6 @@ export default function DiamondSponsors() {
           component="h6"
           color="text.primary"
           variant="body2" sx={{
-            flexDirection: 'column',
-            display: 'flex',
             fontSize: '12px',
             fontWeight: 500,
             textDecoration: 'none',
@@ -73,9 +71,38 @@ export default function DiamondSponsors() {
             marginLeft: '10px',
           }}>
           {/* eslint-disable-next-line stoked-ui/no-hardcoded-labels */}
-          <div>consulting</div>
+          Full Stack Consulting
+        </Typography>
+      </NativeLink>
+      <NativeLink
+        data-ga-event-category="sponsor"
+        data-ga-event-action="docs-premium"
+        data-ga-event-label="stokd-cloud"
+        href="/products/stokd-cloud"
+        rel="noopener"
+        sx={{ textDecoration: 'none', fontDirection: '700'}}
+      >
+        <Box
+          component="img"
+          height="32px"
+          width="32px"
+          src="/static/logo.svg"
+          alt="stokd cloud"
+          title="STOKD CLOUD"
+          loading="lazy"
+        />
+        <Typography
+          component="h6"
+          color="text.primary"
+          variant="body2" sx={{
+            fontSize: '12px',
+            fontWeight: 500,
+            textDecoration: 'none',
+            textTransform: 'uppercase',
+            marginLeft: '10px',
+          }}>
           {/* eslint-disable-next-line stoked-ui/no-hardcoded-labels */}
-          <div>$70 / hr</div>
+          STOKD CLOUD
         </Typography>
       </NativeLink>
       <NativeLink


### PR DESCRIPTION
Closes #384

```markdown
## Summary

Update the `DiamondSponsors` component to refresh the consulting button branding and add a new STOKD CLOUD entry.

**File:** `docs/src/modules/components/DiamondSponsors.js`

---

## Changes Required

### 1. Update Consulting Button
- Replace logo: `/static/logo-no-padding.svg` → `/static/stoked-consulting-logo.svg`
- Change button text: `'consulting / $70 / hr'` → `'Full Stack Consulting'` (single line, no price)

### 2. Add STOKD CLOUD Button
- Add a new button below the consulting entry
- Link: `/products/stokd-cloud`
- Placeholder logo: `/static/logo.svg`
- Display text: `'STOKD CLOUD'`

---

## Acceptance Criteria

- [ ] Consulting button displays `/static/stoked-consulting-logo.svg` as its logo
- [ ] Consulting button label reads exactly `Full Stack Consulting` with no price or slashes
- [ ] STOKD CLOUD button appears immediately below the consulting button in the sponsors list
- [ ] STOKD CLOUD button links to `/products/stokd-cloud`
- [ ] STOKD CLOUD button renders `/static/logo.svg` as its logo
- [ ] No other buttons or layout are affected
- [ ] Component renders without console errors in both light and dark mode

---

## Implementation Notes

- Both buttons should follow the existing data structure/shape used by other entries in `DiamondSponsors.js` (check for a sponsors array or inline JSX pattern before editing)
- Confirm `/static/stoked-consulting-logo.svg` exists in `docs/public/static/` before referencing it; if absent, the asset must be added as part of this work
- `/static/logo.svg` is already in use elsewhere — no asset work needed for the STOKD CLOUD placeholder
- The STOKD CLOUD link (`/products/stokd-cloud`) should be an internal Next.js route; verify the page exists or note it as a known stub
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Diamond sponsor branding with new logos and labels
  * Added STOKD CLOUD as a new sponsor
  * Refined sponsor layout and styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->