### PR TITLE
fix(cdn): break circular dep between cdnInvalidation and cdnMutations

### DIFF
--- a/docs/data/github/snapshots/github-branch-private.json
+++ b/docs/data/github/snapshots/github-branch-private.json
@@ -4,7 +4,7 @@
   "headRef": "bug/fixAutoDeploySite",
   "status": "diverged",
   "aheadBy": 1,
-  "behindBy": 410,
+  "behindBy": 413,
   "totalCommits": 1,
   "url": "https://github.com/stoked-ui/sui/compare/main...bug/fixAutoDeploySite",
   "contributors": [

--- a/docs/src/modules/cdn/cdnInvalidation.ts
+++ b/docs/src/modules/cdn/cdnInvalidation.ts
@@ -2,7 +2,10 @@ import {
   CloudFrontClient,
   CreateInvalidationCommand,
 } from '@aws-sdk/client-cloudfront';
-import { CDN_REGION } from './cdnMutations';
+// Inline rather than importing from cdnMutations to break the circular dep
+// (cdnMutations → cdnInvalidation → cdnMutations) that causes a webpack TDZ
+// ReferenceError at module init time.
+const CDN_REGION = process.env.AWS_REGION || 'us-east-1';
 
 // The CloudFront distribution that fronts the CDN bucket (cdn.stokd.cloud).
 // Wired in via SST (infra/cdn-site.ts) as an environment variable on the docs


### PR DESCRIPTION
fix(cdn): break circular dep between cdnInvalidation and cdnMutations

- cdnInvalidation.ts: inline CDN_REGION constant instead of importing from
  cdnMutations to eliminate the circular dependency that caused a webpack TDZ
  ReferenceError crashing all CDN API routes at module init time
- github-branch-private.json: update behindBy snapshot count (410 → 413)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test snapshots.
  * Improved internal module dependencies and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->